### PR TITLE
ci: validate pkgdown and harden GitHub Actions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,19 @@ If you’ve found a bug, please file an issue that illustrates the bug with a mi
 *  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
    Contributions with test cases included are easier to accept.  
 
+### Package website
+
+Every exported topic must be listed in `_pkgdown.yml`. Validate the reference
+index locally before opening a pull request:
+
+```sh
+Rscript --vanilla dev/check-pkgdown.R
+```
+
+This check validates the pkgdown configuration without publishing the website.
+GitHub Actions runs the same validation for pull requests and deploys the full
+site only from `devel`.
+
 ## Code of Conduct
 
 Please note that the dar project is released with a

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - enhancement
+    open-pull-requests-limit: 5

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -22,9 +22,18 @@
 
 on:
   push:
+    branches:
+      - devel
   pull_request:
 
 name: R-CMD-check-bioc
+
+permissions:
+  contents: read
+
+concurrency:
+  group: r-cmd-check-bioc-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 ## These environment variables control whether to run GHA code later on that is
 ## specific to testthat, covr, and pkgdown.
@@ -39,7 +48,6 @@ env:
   run_pkgdown: 'true'
   has_RUnit: 'false'
   cache-version: 'cache-v1'
-  run_docker: 'true'
   bioc_version: 'bioc-release'
   ## Valid options are:
   ##    "bioc-release"
@@ -120,12 +128,12 @@ jobs:
       ## https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
       ## If they update their steps, we will also need to update ours.
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       ## R is already included in the Bioconductor docker images
       - name: Setup R from r-lib
         if: runner.os != 'Linux'
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
@@ -133,7 +141,7 @@ jobs:
       ## pandoc is already included in the Bioconductor docker images
       - name: Setup pandoc from r-lib
         if: runner.os != 'Linux'
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       ## Create the path that will be used for caching packages on Linux
       - name: Create R_LIBS_USER on Linux
@@ -146,7 +154,7 @@ jobs:
       ## Use cached R packages
       - name: Restore R package cache
         if: "!contains(github.event.head_commit.message, '/nocache')"
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ matrix.config.r }}-${{ matrix.config.bioc }}-${{ env.cache-version }}
@@ -336,30 +344,52 @@ jobs:
         if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
-        ## Note that you need to run pkgdown::deploy_to_branch(new_process = FALSE)
-        ## at least one locally before this will work. This creates the gh-pages
-        ## branch (erasing anything you haven't version controlled!) and
-        ## makes the git history recognizable by pkgdown.
 
-      - name: Install deploy dependencies
+      - name: Upload pkgdown site
         if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
-        run: |
-          apt-get update && apt-get -y install rsync
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: pkgdown-site
+          path: docs
+          if-no-files-found: error
+          retention-days: 1
 
-      - name: Deploy pkgdown site to GitHub pages 🚀
-        if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
-        uses: JamesIves/github-pages-deploy-action@releases/v4
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ runner.os }}-${{ matrix.config.r }}-${{ matrix.config.bioc }}-results
+          path: check
+          if-no-files-found: warn
+          retention-days: 7
+
+  deploy-pkgdown:
+    name: Deploy pkgdown site
+    needs: build-check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Download pkgdown site
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: pkgdown-site
+          path: docs
+
+      - name: Install deployment dependency
+        run: sudo apt-get update && sudo apt-get install -y rsync
+
+      - name: Deploy pkgdown site to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@800bbc83122db9d4c38fcd284782d5afe62e52df # releases/v4
         with:
           clean: false
           branch: gh-pages
           folder: docs
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@master
-        with:
-          name: ${{ runner.os }}-${{ matrix.config.r }}-${{ matrix.config.bioc }}-results
-          path: check
 
 
   ## Code adapted from
@@ -367,28 +397,24 @@ jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
     needs: build-check
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel' && !contains(github.event.head_commit.message, '/nodocker')
     steps:
       - name: Checkout Repository
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Register repo name
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
         id: reg_repo_name
         run: |
           echo CONT_IMG_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
       - name: Set up QEMU
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel'"
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -401,8 +427,7 @@ jobs:
       ## https://seandavi.github.io/BuildABiocWorkshop/articles/HOWTO_BUILD_WORKSHOP.html.
 
       - name: Build and Push Docker
-        if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && github.ref == 'refs/heads/devel' && success()"
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -268,9 +268,14 @@ jobs:
         shell: Rscript {0}
 
       - name: Install pkgdown
-        if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
+        if: env.run_pkgdown == 'true' && runner.os == 'Linux' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/devel')
         run: |
           remotes::install_cran("pkgdown")
+        shell: Rscript {0}
+
+      - name: Validate pkgdown configuration
+        if: env.run_pkgdown == 'true' && runner.os == 'Linux' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/devel')
+        run: source("dev/check-pkgdown.R")
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/issue-branch.yml
+++ b/.github/workflows/issue-branch.yml
@@ -1,4 +1,9 @@
 name: Create Issue Branch
+
+concurrency:
+  group: issue-branch-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 on:
   issues:
     types: [assigned]
@@ -8,13 +13,13 @@ on:
 jobs:
   create_issue_branch_job:
     runs-on: ubuntu-latest
-    permissions:       
+    permissions:
       contents: write
       issues: write
       pull-requests: write
     steps:
     - name: Create Issue Branch
       id: Create_Issue_Branch
-      uses: robvanderleek/create-issue-branch@main
+      uses: robvanderleek/create-issue-branch@1327274ffa72a698c514c5542edb05322c8e8308 # main, pinned 2026-08-03
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scientific-validation.yml
+++ b/.github/workflows/scientific-validation.yml
@@ -32,6 +32,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: scientific-validation-${{ github.event_name }}-${{ inputs.profile || 'full' }}-${{ inputs.engine || 'all' }}
+  cancel-in-progress: true
+
 jobs:
   bioc-config:
     runs-on: ubuntu-latest
@@ -89,14 +93,14 @@ jobs:
       R_LIBS_USER: /__w/_temp/ScientificValidationLibrary
       VALIDATION_PROFILE: ${{ needs.bioc-config.outputs.profile }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Create validation library
         shell: bash
         run: mkdir -p "$R_LIBS_USER"
 
       - name: Restore validation package cache
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ${{ env.R_LIBS_USER }}
           key: scientific-validation-${{ matrix.engine }}-R${{ needs.bioc-config.outputs.r }}-Bioc${{ needs.bioc-config.outputs.bioc }}-${{ hashFiles('DESCRIPTION', 'dev/scientific-validation/profiles.csv') }}
@@ -162,7 +166,7 @@ jobs:
 
       - name: Upload engine artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scientific-validation-${{ matrix.engine }}
           path: validation-results/${{ matrix.engine }}
@@ -174,20 +178,20 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ needs.bioc-config.outputs.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Install report dependencies
         shell: Rscript {0}
         run: install.packages(c("dplyr", "ggplot2", "knitr", "rmarkdown"))
 
       - name: Download engine artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           pattern: scientific-validation-*
           path: validation-artifacts
@@ -200,7 +204,7 @@ jobs:
 
       - name: Upload aggregate report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scientific-validation-report
           path: validation-report

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+ci:
+  autoupdate_schedule: quarterly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-yaml

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -33,10 +33,12 @@ reference:
   - step_corncob
   - step_deseq
   - step_lefse
+  - step_linda
   - step_maaslin
-  - step_wilcox 
+  - step_wilcox
 - title: "Exploration"
   contents:
+  - tidy_results
   - abundance_plt
   - corr_heatmap
   - exclusion_plt

--- a/dev/check-pkgdown.R
+++ b/dev/check-pkgdown.R
@@ -1,0 +1,18 @@
+if (!requireNamespace("pkgdown", quietly = TRUE)) {
+  stop(
+    "Package 'pkgdown' is required. Install it with install.packages('pkgdown').",
+    call. = FALSE
+  )
+}
+
+if (!rmarkdown::pandoc_available()) {
+  stop(
+    paste(
+      "Pandoc is required to validate pkgdown.",
+      "Install Pandoc or set RSTUDIO_PANDOC to its binary directory."
+    ),
+    call. = FALSE
+  )
+}
+
+pkgdown::check_pkgdown(".")


### PR DESCRIPTION
## Summary

- add `step_linda` and `tidy_results` to the pkgdown reference index;
- validate pkgdown metadata on pull requests with a reusable local helper;
- restrict push checks to `devel` so feature branches with open pull requests run one check matrix;
- add concurrency cancellation for superseded package and scientific-validation runs;
- pin every GitHub Action to an immutable commit SHA and enable Dependabot updates;
- configure deterministic pre-commit.ci checks;
- apply read-only permissions to validation and isolate pkgdown deployment in a write-enabled push-only job;
- upload the built site between validation and deployment instead of publishing from the check job;
- restrict the Docker publishing job to successful pushes to `devel`.

## Root cause

pkgdown was only checked after changes reached `devel`, so missing exported topics were not detected before merge. The workflows also combined validation and deployment responsibilities, used mutable Action references, and triggered duplicate matrices for same-repository pull requests.

## Developer impact

Pull requests now fail early when the pkgdown reference index is incomplete. Validation remains read-only and does not publish artifacts externally. Direct pushes to `devel` still run the full matrix, publish pkgdown, and build the Docker image.

## Validation

- `pkgdown::check_pkgdown()`: no problems found;
- full `pkgdown::build_site_github_pages()`: completed successfully;
- actionlint 1.7.12: all workflows valid;
- pre-commit hooks: all passed;
- YAML parsing and immutable Action-reference audit: passed;
- `git diff --check`: passed.

Closes #150
Closes #156